### PR TITLE
Fix template.yaml inconsistencies and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Based on the input parameters, the workflow will go through multiple steps where
 ## Enable Scheduled Rule (Optional)    
 If you need to run the solution on a schedule, you can 
    
-   (a). Uncomment the resource **PrePostBackupEventsScheduledRule**  in template.yaml (line numbers 185-222)
+   (a). Uncomment the resource PrePostBackupEventsScheduledRule in template.yaml (line numbers 189-226)
    
    (b). Edit the cron expression on line number 190 as per your requirement. [How to set CRON expression](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-rule-schedule.html#eb-cron-expressions)
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Based on the input parameters, the workflow will go through multiple steps where
 ## Enable Scheduled Rule (Optional)    
 If you need to run the solution on a schedule, you can 
    
-   (a). Uncomment the resource PrePostBackupEventsScheduledRule in template.yaml (line numbers 189-226)
+   (a). Uncomment the resource **PrePostBackupEventsScheduledRule** in template.yaml (line numbers 189-226)
    
    (b). Edit the cron expression on line number 190 as per your requirement. [How to set CRON expression](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-rule-schedule.html#eb-cron-expressions)
 

--- a/template.yaml
+++ b/template.yaml
@@ -218,7 +218,7 @@ Resources:
 #                  OutputS3KeyPrefix: post-script-logs
 #              BackupDetails:
 #                BackupVaultName: !Ref BackupVault
-#                IamRoleArn: !Ref BackupJobExecutionRole
+#                IamRoleArn: !GetAtt BackupJobExecutionRole.Arn
 #          # InputPath: $.detail
 #          RetryPolicy:
 #            MaximumRetryAttempts: 2


### PR DESCRIPTION
This PR fixes several inconsistencies in the template.yaml file and documentation:

1. Fixes incorrect IamRoleArn reference in PrePostBackupEventsScheduledRule:
   - Changed: `IamRoleArn: !Ref BackupJobExecutionRole`
   - To: `IamRoleArn: !GetAtt BackupJobExecutionRole.Arn`

   This fixes the following error that occurs when using the original template:
   ```json
   {
     "errorMessage": "An error occurred (AccessDeniedException) when calling the StartBackupJob operation: Insufficient privileges to perform this action.",
     "errorType": "ClientError",
     "requestId": "c2d55fe8-f43c-4e45-9db5-5d054aa55780",
     "stackTrace": [
       "  File \"/var/task/app.py\", line 38, in lambda_handler\n    result = start_backup_job(event)\n",
       "  File \"/var/task/app.py\", line 9, in start_backup_job\n    response = backup_client.start_backup_job(\n",
       "  File \"/var/runtime/botocore/client.py\", line 602, in _api_call\n    return self._make_api_call(operation_name, kwargs)\n",
       "  File \"/var/runtime/botocore/context.py\", line 123, in wrapper\n    return func(*args, **kwargs)\n",
       "  File \"/var/runtime/botocore/client.py\", line 1078, in _make_api_call\n    raise error_class(parsed_response, operation_name)\n"
     ]
   }


2. Updates line number references in documentation:

Changed README.md reference from (185-222) to (189-226) to match actual template.yaml line numbers

The original template was using !Ref BackupJobExecutionRole which caused permission issues when executing the backup job. The correct reference should be !GetAtt BackupJobExecutionRole.Arn to properly pass the complete IAM role ARN to the backup job.

This fix ensures that the backup job has the proper permissions to execute, preventing the AccessDeniedException error that users were experiencing with the original template.